### PR TITLE
Add PrivateRoute component to protect create-feedback route

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,12 +4,18 @@ import "./Custom-amplify-styles.css";
 import HomePage from "./pages/HomePage";
 import CreateFeedback from "./pages/CreateFeedback";
 import Sign from "./pages/Sign";
+import PrivateRoute from "./components/PrivateRoute";
+
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage />} />
-        <Route path="/create-feedback" element={<CreateFeedback />} />
+
+        {/* add the private route here */}
+        <Route element={<PrivateRoute />}>
+          <Route path="/create-feedback" element={<CreateFeedback />} />
+        </Route>
         <Route path="/sign" element={<Sign />} />
       </Routes>
     </BrowserRouter>

--- a/client/src/components/PrivateRoute.jsx
+++ b/client/src/components/PrivateRoute.jsx
@@ -1,0 +1,10 @@
+import { useAuthenticator } from "@aws-amplify/ui-react";
+import { Navigate, Outlet } from "react-router-dom";
+
+const PrivateRoute = () => {
+  const { user } = useAuthenticator((context) => [context.user]);
+
+  return user ? <Outlet /> : <Navigate to="/sign" />;
+};
+
+export default PrivateRoute;


### PR DESCRIPTION
This pull request introduces a new `PrivateRoute` component to the application, which ensures that certain routes are only accessible to authenticated users. The most important changes are:

Authentication and routing:

* [`client/src/App.jsx`](diffhunk://#diff-51b002bf85fbd146b38871b89ba0d41c2bead37756295748c67206aac23ddc9aR7-R18): Added the `PrivateRoute` component and wrapped the `/create-feedback` route with it to restrict access to authenticated users.
* [`client/src/components/PrivateRoute.jsx`](diffhunk://#diff-16fd0eadc0b3230a08d89395c14df95bd6dd40a09db0e227f0ebc89a2da09d65R1-R10): Created the `PrivateRoute` component, which uses the `useAuthenticator` hook from `@aws-amplify/ui-react` to check if the user is authenticated. If not, it redirects to the `/sign` page.