### PR TITLE
refactor: fix, clean up configuration and improve formatting

### DIFF
--- a/infrastructure/live/modules/apigateway/add_feedback/terragrunt.hcl
+++ b/infrastructure/live/modules/apigateway/add_feedback/terragrunt.hcl
@@ -9,28 +9,29 @@ terraform {
 }
 
 dependency "create_feedback_function" {
-  config_path = "../../backend_functions"
-    mock_outputs = {
-        lambda_function_name = "add_feedback"
-        lambda_function_invoke_arn = "arn:aws:lambda:eu-central-1:123456789012:function:add_feedback"
-    }
+  config_path  = "../../backend_functions"
+  skip_outputs = true
+  mock_outputs = {
+    lambda_function_name       = "add_feedback"
+    lambda_function_invoke_arn = "arn:aws:lambda:eu-central-1:123456789012:function:add_feedback"
+  }
 }
 
 dependency "cognito" {
   config_path = "../../cognito"
-    mock_outputs = {
-        cognito_client_id = "8ckehg57gg5ae60m1b2s70igc"
-        cognito_issuer_url = "https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_AZ0E6IBOe"
-    }
+  mock_outputs = {
+    cognito_client_id  = "8ckehg57gg5ae60m1b2s70igc"
+    cognito_issuer_url = "https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_AZ0E6IBOe"
+  }
 }
 
 
 inputs = {
-  api_name = "feedback-api"
-  integration_method = "POST"
-  invoke_arn = dependency.create_feedback_function.outputs.lambda_function_invoke_arn
-  route_key = "CREATE /feedback" 
+  api_name             = "feedback-api"
+  integration_method   = "POST"
+  invoke_arn           = dependency.create_feedback_function.outputs.lambda_function_invoke_arn
+  route_key            = "CREATE /feedback"
   lambda_function_name = dependency.create_feedback_function.outputs.lambda_function_name
-  cognito_client_id = dependency.cognito.outputs.cognito_client_id
-  cognito_issuer_url = dependency.cognito.outputs.cognito_issuer_url
+  cognito_client_id    = dependency.cognito.outputs.cognito_client_id
+  cognito_issuer_url   = dependency.cognito.outputs.cognito_issuer_url
 }

--- a/infrastructure/live/modules/backend_functions/terragrunt.hcl
+++ b/infrastructure/live/modules/backend_functions/terragrunt.hcl
@@ -1,5 +1,5 @@
 include "root" {
-    path = find_in_parent_folders()
+  path = find_in_parent_folders()
 }
 
 terraform {
@@ -7,5 +7,5 @@ terraform {
 }
 
 inputs = {
-   table_name = "feedback-table"
+  table_name = "feedback-table"
 }

--- a/infrastructure/live/modules/cloudfront/terragrunt.hcl
+++ b/infrastructure/live/modules/cloudfront/terragrunt.hcl
@@ -1,21 +1,21 @@
 include "root" {
-    path = find_in_parent_folders()
+  path = find_in_parent_folders()
 }
 
 terraform {
-    source ="../../../modules/cloudfront_stack"
+  source = "../../../modules/cloudfront_stack"
 }
 
 dependency "s3" {
-    config_path = "../s3_stack"
-    mock_outputs = {
-        bucket_name = "feedback-app-hosting-bucket"
-        bucket_arn = "arn:aws:s3:::feedback-app-hosting-bucket"
-    }
+  config_path = "../s3_stack"
+  mock_outputs = {
+    s3_bucket_name = "feedback-app-hosting-bucket"
+    s3_bucket_arn  = "arn:aws:s3:::feedback-app-hosting-bucket"
+  }
 }
 
 
-inputs ={
-    s3_bucket_name = dependency.s3.outputs.s3_bucket_name
-    s3_bucket_arn = dependency.s3.outputs.s3_bucket_arn
+inputs = {
+  s3_bucket_name = dependency.s3.outputs.s3_bucket_name
+  s3_bucket_arn  = dependency.s3.outputs.s3_bucket_arn
 }

--- a/infrastructure/live/modules/cognito/terragrunt.hcl
+++ b/infrastructure/live/modules/cognito/terragrunt.hcl
@@ -1,5 +1,5 @@
 include "root" {
-    path = find_in_parent_folders()
+  path = find_in_parent_folders()
 }
 
 terraform {
@@ -7,7 +7,7 @@ terraform {
 }
 
 inputs = {
-    user_pool_name = "feedback-app-user-pool"
-    client_name = "feedback-app-client"
-    callback_urls = ["http://localhost:3000"]   
+  user_pool_name = "feedback-app-user-pool"
+  client_name    = "feedback-app-client"
+  callback_urls  = ["http://localhost:3000"]
 }

--- a/infrastructure/live/modules/dynamodb_stack/terragrunt.hcl
+++ b/infrastructure/live/modules/dynamodb_stack/terragrunt.hcl
@@ -2,10 +2,10 @@ include "root" {
   path = find_in_parent_folders()
 }
 
-terraform{
-    source ="../../../modules/dynamodb_stack"
+terraform {
+  source = "../../../modules/dynamodb_stack"
 }
 
 inputs = {
-    table_name = "feedback_table"
+  table_name = "feedback_table"
 }

--- a/infrastructure/modules/backend_functions_stack/add_feedback.tf
+++ b/infrastructure/modules/backend_functions_stack/add_feedback.tf
@@ -1,6 +1,6 @@
 resource "aws_lambda_function" "add_feedback" {
 
-  filename      = "lambda_function_payload.zip"
+  filename      = "add_feedback_function.zip"
   function_name = "add_feedback"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.mjs"
@@ -34,7 +34,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 data "archive_file" "lambda" {
   type        = "zip"
   source_dir  = "${path.cwd}/../../../../../../functions/add_feedback"
-  output_path = "lambda.zip"
+  output_path = "add_feedback_function.zip"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {

--- a/infrastructure/modules/cloudfront_stack/main.tf
+++ b/infrastructure/modules/cloudfront_stack/main.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudfront_distribution" "feedback_app" {
   origin {
-    domain_name              = var.s3_bucket_name
+    domain_name              = "${var.s3_bucket_name}.s3.amazonaws.com"
     origin_id                = var.s3_bucket_name
     origin_access_control_id = aws_cloudfront_origin_access_control.this.id
 
@@ -16,10 +16,17 @@ resource "aws_cloudfront_distribution" "feedback_app" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = var.s3_bucket_name
 
+
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
   }
 
   restrictions {

--- a/infrastructure/modules/init_stack/main.tf
+++ b/infrastructure/modules/init_stack/main.tf
@@ -42,7 +42,8 @@ resource "aws_iam_policy" "github_actions_policy" {
           "iam:*",
           "lambda:*",
           "cognito-idp:*",
-          "cognito-sync:*"
+          "cognito-sync:*",
+          "apigateway:*",
         ],
         "Resource" : "*"
       }


### PR DESCRIPTION
I implemented some fixes for Cloudfront and lambda stacks. There is another issue in the API gateway stack regarding the stack called twice from two different terragrunt configurations files but the two files don't have the same number of inputs which causes missing variables. I would recommend to use foreach to solve the issue.